### PR TITLE
Allow expressions inside DOM

### DIFF
--- a/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
@@ -382,6 +382,7 @@ tagOrExpr :: { Expr () }
 
 tag :: { Expr () }
   : '(' '.' qualIdent ')'                              { tag1  $1 $4 (ExprIdent () $3) }
+  | '(' '.' 'in' expr ')'                              { tagExpr $4 }
   | '(' '.' qualIdent attrs ')'                        { tagA  $1 $5 (ExprIdent () $3) $4 }
   | '(' '.' qualIdent attrs 'in' many1S(tagOrExpr) ')' { tagAC $1 $7 (ExprIdent () $3) $4 $6 }
   | '(' '.' qualIdent 'in' many1S(tagOrExpr) ')'       { tagC  $1 $6 (ExprIdent () $3) $5 }

--- a/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
@@ -382,7 +382,7 @@ tagOrExpr :: { Expr () }
 
 tag :: { Expr () }
   : '(' '.' qualIdent ')'                              { tag1  $1 $4 (ExprIdent () $3) }
-  | '(' '.' 'in' expr ')'                              { tagExpr $4 }
+  | '(' '=' expr ')'                                   { tagExpr $3 }
   | '(' '.' qualIdent attrs ')'                        { tagA  $1 $5 (ExprIdent () $3) $4 }
   | '(' '.' qualIdent attrs 'in' many1S(tagOrExpr) ')' { tagAC $1 $7 (ExprIdent () $3) $4 $6 }
   | '(' '.' qualIdent 'in' many1S(tagOrExpr) ')'       { tagC  $1 $6 (ExprIdent () $3) $5 }

--- a/lib/purescript-cst/src/Language/PureScript/CST/Types.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Types.hs
@@ -469,6 +469,10 @@ consSep sep x (Separated hd tl) =
 tag :: Expr () -> Expr () -> Expr () -> Expr ()
 tag tid record inner = ExprApp () (ExprApp () tid record) inner
 
+-- | Nest arbitrary expressions inside some DOM
+tagExpr :: Expr () -> Expr ()
+tagExpr e = e
+
 -- | Simple DOM tag with no attributes and no child elements
 tag1 :: SourceToken -> SourceToken -> Expr () -> Expr ()
 tag1 opn cls tid = 


### PR DESCRIPTION
Modify the parser slightly to allow the following to compile:

```
(.div in
  (= if true
      then (.h1 text: "True2!")
      else (.h1 text: "False!"))
  (.h1 text: "Changed it again"))
```