### PR TITLE
Add built-in ConcreteTypeName constraint

### DIFF
--- a/lib/purescript-ast/src/Language/PureScript/Constants/Prim.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Constants/Prim.hs
@@ -109,6 +109,9 @@ pattern RowListCons = Qualified (Just PrimRowList) (ProperName "Cons")
 pattern PrimSymbol :: ModuleName
 pattern PrimSymbol = ModuleName "Prim.Symbol"
 
+pattern SymbolConcreteTypeName :: Qualified (ProperName 'ClassName)
+pattern SymbolConcreteTypeName = Qualified (Just PrimSymbol) (ProperName "ConcreteTypeName")
+
 pattern SymbolCompare :: Qualified (ProperName 'ClassName)
 pattern SymbolCompare = Qualified (Just PrimSymbol) (ProperName "Compare")
 

--- a/lib/purescript-ast/src/Language/PureScript/Environment.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Environment.hs
@@ -442,7 +442,8 @@ primRowListTypes =
 primSymbolTypes :: M.Map (Qualified (ProperName 'TypeName)) (SourceType, TypeKind)
 primSymbolTypes =
   M.fromList $ mconcat
-    [ primClass (primSubName C.moduleSymbol "Append")  (\kind -> kindSymbol -:> kindSymbol -:> kindSymbol -:> kind)
+    [ primClass (primSubName C.moduleSymbol "ConcreteTypeName")  (\kind -> kindType -:> kindSymbol -:> kind)
+    , primClass (primSubName C.moduleSymbol "Append")  (\kind -> kindSymbol -:> kindSymbol -:> kindSymbol -:> kind)
     , primClass (primSubName C.moduleSymbol "Compare") (\kind -> kindSymbol -:> kindSymbol -:> kindOrdering -:> kind)
     , primClass (primSubName C.moduleSymbol "Cons")    (\kind -> kindSymbol -:> kindSymbol -:> kindSymbol -:> kind)
     ]
@@ -547,8 +548,16 @@ primRowListClasses =
 primSymbolClasses :: M.Map (Qualified (ProperName 'ClassName)) TypeClassData
 primSymbolClasses =
   M.fromList
+    -- class ConcreteTypeName (typ :: Type) (name :: Symbol) | type -> name
+    [ (primSubName C.moduleSymbol "ConcreteTypeName", makeTypeClassData
+        [ ("typ", Just kindType)
+        , ("name", Just kindSymbol)
+        ] [] []
+        [ FunctionalDependency [0] [1] ]
+        True)
+
     -- class Append (left :: Symbol) (right :: Symbol) (appended :: Symbol) | left right -> appended, right appended -> left, appended left -> right
-    [ (primSubName C.moduleSymbol "Append", makeTypeClassData
+    , (primSubName C.moduleSymbol "Append", makeTypeClassData
         [ ("left", Just kindSymbol)
         , ("right", Just kindSymbol)
         , ("appended", Just kindSymbol)

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -120,7 +120,8 @@ primSymbolDocsModule = Module
   { modName = P.moduleNameFromString "Prim.Symbol"
   , modComments = Just "The Prim.Symbol module is embedded in the PureScript compiler. Unlike `Prim`, it is not imported implicitly. It contains automatically solved type classes for working with `Symbols`."
   , modDeclarations =
-      [ symbolAppend
+      [ symbolConcreteTypeName
+      , symbolAppend
       , symbolCompare
       , symbolCons
       ]
@@ -497,6 +498,11 @@ rowToList = primClassOf (P.primSubName "RowList") "RowToList" $ T.unlines
   [ "Compiler solved type class for generating a `RowList` from a closed row"
   , "of types.  Entries are sorted by label and duplicates are preserved in"
   , "the order they appeared in the row."
+  ]
+
+symbolConcreteTypeName :: Declaration
+symbolConcreteTypeName = primClassOf (P.primSubName "Symbol") "ConcreteTypeName" $ T.unlines
+  [ "Compiler solved type class for gettings the qualified name of a type."
   ]
 
 symbolAppend :: Declaration


### PR DESCRIPTION
This primitive, compiler solved constraint allows us to safely coerce any value
with a concrete type known at compile time.
